### PR TITLE
Upgrade from Python2 to Python3

### DIFF
--- a/GuindexProject/GuindexProject/settings.py
+++ b/GuindexProject/GuindexProject/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
-import secrets
+import GuindexProject.guin_secrets as secrets
 
 PROJECT_TITLE = "Guindex"
 

--- a/GuindexProject/TelegramUser/TelegramUserUtils.py
+++ b/GuindexProject/TelegramUser/TelegramUserUtils.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
 
 from TelegramUser.models import TelegramUser
-from TelegramUserParameters import TelegramUserParameters
+from TelegramUser.TelegramUserParameters import TelegramUserParameters
 
 logger = logging.getLogger(__name__)
 

--- a/GuindexProject/TelegramUser/models.py
+++ b/GuindexProject/TelegramUser/models.py
@@ -3,7 +3,7 @@ import logging
 from django.db import models
 from django.contrib.auth.models import User
 
-from TelegramUserParameters import TelegramUserParameters
+from TelegramUser.TelegramUserParameters import TelegramUserParameters
 
 logger = logging.getLogger(__name__)
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 Once the Guindex source code has been cloned please follow the below steps to
 get the Guindex development web server up and running:
 
-Note: Guindex uses python 2.7.
+Note: Guindex uses python 3.7.
 
 0) pip version >= 20.3.4 is required:
    wget https://bootstrap.pypa.io/pip/2.7/get-pip.pywget https://bootstrap.pypa.io/pip/2.7/get-pip.pywget https://bootstrap.pypa.io/pip/2.7/get-pip.py
    python get-pip.py
 1) Install python requirements: `pip install -r requirements.txt`
-2) Get secrets.py file from howardrj@tcd.ie and place in GuindexProject/GuindexProject directory.
-3) Set GUINDEX_DB_LOCATION variable in secrets.py.
+2) Get guin_secrets.py file from howardrj@tcd.ie and place in GuindexProject/GuindexProject directory.
+3) Set GUINDEX_DB_LOCATION variable in guin_secrets.py.
    This will be the location of your development Guindex database.
 4) Run database migrations: `python manage.py migrate`
 5) Create cache tables: `python manage.py createcachetable guindex_cache`

--- a/README.md
+++ b/README.md
@@ -2,19 +2,16 @@
 Once the Guindex source code has been cloned please follow the below steps to
 get the Guindex development web server up and running:
 
-Note: Guindex uses python 3.7.
+Create a virtual environment that uses python 3.9
 
-0) pip version >= 20.3.4 is required:
-   wget https://bootstrap.pypa.io/pip/2.7/get-pip.pywget https://bootstrap.pypa.io/pip/2.7/get-pip.pywget https://bootstrap.pypa.io/pip/2.7/get-pip.py
-   python get-pip.py
 1) Install python requirements: `pip install -r requirements.txt`
 2) Get guin_secrets.py file from howardrj@tcd.ie and place in GuindexProject/GuindexProject directory.
 3) Set GUINDEX_DB_LOCATION variable in guin_secrets.py.
    This will be the location of your development Guindex database.
-4) Run database migrations: `python manage.py migrate`
-5) Create cache tables: `python manage.py createcachetable guindex_cache`
-6) Create map: `python manage.py GuindexMap`
-7) Start django server: `python manage.py runserver <ip>:<port>` 
+4) Run database migrations: `sudo env "PATH=$PATH" python manage.py migrate`
+5) Create cache tables: `sudo env "PATH=$PATH" python manage.py createcachetable guindex_cache`
+6) Create map: `sudo env "PATH=$PATH" python manage.py GuindexMap`
+7) Start django server: `sudo env "PATH=$PATH" python manage.py runserver <ip>:<port>` 
    where `ip` is the IP address of your machine and `port` is any valid, available TCP port.
 8) Open a browser and go to `http://<ip>:<port>`
 9) Happy Guindexing! :)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==1.11.7
+django==1.11.20
 python-telegram-bot==10.0.1
 dropbox==8.7.1
 gunicorn==19.7.1


### PR DESCRIPTION
Want to upgrade to python3 so as to use the folium package to do the map creation. 

Changes include:

- Renaming `secrets.py` to `guin_secrets.py` as the module `secrets` is part of the python standard library from python 3.6 onwards and `import secrets` was importing this rather than the secrets file.
- Changing Django version due to a known compatibility issue between Django versions < 1.11.17 and python 3.7+ (see [here](https://stackoverflow.com/questions/51265858/syntaxerror-generator-expression-must-be-parenthesized))
- Updating some import paths.
- Updating readme

This seems to be working grand.

Issue: https://github.com/howardrj/Guindex/issues/35